### PR TITLE
fix(user): change to throw useful exception

### DIFF
--- a/services/user.py
+++ b/services/user.py
@@ -82,7 +82,7 @@ def user_suggested(username):
     :param username:
     :return: Suggested movies
     """
-    pass
+    raise NotImplementedError()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, when a user hits the `/users/<username>/suggested` route, a large exception is thrown
in the logs since this route is not implemented. A `NotImplementedError` would be more useful for
the time being.

Resolves https://github.com/umermansoor/microservices/issues/4